### PR TITLE
Fix enum for array type in create/update webhook models

### DIFF
--- a/docs/CreateWebhook.md
+++ b/docs/CreateWebhook.md
@@ -9,6 +9,39 @@ Name | Type | Description | Notes
 **type** | **String** | Type of the webhook | [optional] [default to &#39;transactional&#39;]
 
 
+<a name="[EventsEnum]"></a>
+## Enum: [EventsEnum]
+
+
+* `hardBounce` (value: `"hardBounce"`)
+
+* `softBounce` (value: `"softBounce"`)
+
+* `blocked` (value: `"blocked"`)
+
+* `spam` (value: `"spam"`)
+
+* `delivered` (value: `"delivered"`)
+
+* `request` (value: `"request"`)
+
+* `click` (value: `"click"`)
+
+* `invalid` (value: `"invalid"`)
+
+* `deferred` (value: `"deferred"`)
+
+* `opened` (value: `"opened"`)
+
+* `uniqueOpened` (value: `"uniqueOpened"`)
+
+* `unsubscribed` (value: `"unsubscribed"`)
+
+* `listAddition` (value: `"listAddition"`)
+
+
+
+
 <a name="TypeEnum"></a>
 ## Enum: TypeEnum
 

--- a/docs/UpdateWebhook.md
+++ b/docs/UpdateWebhook.md
@@ -8,3 +8,36 @@ Name | Type | Description | Notes
 **events** | **[String]** | Events triggering the webhook. Possible values for Transactional type webhook – request, delivered, hardBounce, softBounce, blocked, spam, invalid, deferred, click, opened, uniqueOpened and unsubscribed and possible values for Marketing type webhook – spam, opened, click, hardBounce, softBounce, unsubscribed, listAddition and delivered | [optional] 
 
 
+<a name="[EventsEnum]"></a>
+## Enum: [EventsEnum]
+
+
+* `hardBounce` (value: `"hardBounce"`)
+
+* `softBounce` (value: `"softBounce"`)
+
+* `blocked` (value: `"blocked"`)
+
+* `spam` (value: `"spam"`)
+
+* `delivered` (value: `"delivered"`)
+
+* `request` (value: `"request"`)
+
+* `click` (value: `"click"`)
+
+* `invalid` (value: `"invalid"`)
+
+* `deferred` (value: `"deferred"`)
+
+* `opened` (value: `"opened"`)
+
+* `uniqueOpened` (value: `"uniqueOpened"`)
+
+* `unsubscribed` (value: `"unsubscribed"`)
+
+* `listAddition` (value: `"listAddition"`)
+
+
+
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sib-api-v3-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sib-api-v3-sdk",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Official SendinBlue provided RESTFul API V3 nodejs library",
   "license": "ISC",
   "main": "src/index.js",

--- a/src/model/CreateWebhook.js
+++ b/src/model/CreateWebhook.js
@@ -94,7 +94,7 @@
   exports.prototype['description'] = undefined;
   /**
    * Events triggering the webhook. Possible values for Transactional type webhook – request, delivered, hardBounce, softBounce, blocked, spam, invalid, deferred, click, opened, uniqueOpened and unsubscribed and possible values for Marketing type webhook – spam, opened, click, hardBounce, softBounce, unsubscribed, listAddition & delivered
-   * @member {Array.<String>} events
+   * @member {Array.<module:model/CreateWebhook.EventsEnum>} events
    */
   exports.prototype['events'] = undefined;
   /**
@@ -104,6 +104,78 @@
    */
   exports.prototype['type'] = 'transactional';
 
+
+  /**
+   * Allowed values for the <code>events</code> property.
+   * @enum {String}
+   * @readonly
+   */
+  exports.EventsEnum = {
+    /**
+     * value: "hardBounce"
+     * @const
+     */
+    "hardBounce": "hardBounce",
+    /**
+     * value: "softBounce"
+     * @const
+     */
+    "softBounce": "softBounce",
+    /**
+     * value: "blocked"
+     * @const
+     */
+    "blocked": "blocked",
+    /**
+     * value: "spam"
+     * @const
+     */
+    "spam": "spam",
+    /**
+     * value: "delivered"
+     * @const
+     */
+    "delivered": "delivered",
+    /**
+     * value: "request"
+     * @const
+     */
+    "request": "request",
+    /**
+     * value: "click"
+     * @const
+     */
+    "click": "click",
+    /**
+     * value: "invalid"
+     * @const
+     */
+    "invalid": "invalid",
+    /**
+     * value: "deferred"
+     * @const
+     */
+    "deferred": "deferred",
+    /**
+     * value: "opened"
+     * @const
+     */
+    "opened": "opened",
+    /**
+     * value: "uniqueOpened"
+     * @const
+     */
+    "uniqueOpened": "uniqueOpened",
+    /**
+     * value: "unsubscribed"
+     * @const
+     */
+    "unsubscribed": "unsubscribed",
+    /**
+     * value: "listAddition"
+     * @const
+     */
+    "listAddition": "listAddition"  };
 
   /**
    * Allowed values for the <code>type</code> property.

--- a/src/model/UpdateWebhook.js
+++ b/src/model/UpdateWebhook.js
@@ -89,10 +89,82 @@
   exports.prototype['description'] = undefined;
   /**
    * Events triggering the webhook. Possible values for Transactional type webhook – request, delivered, hardBounce, softBounce, blocked, spam, invalid, deferred, click, opened, uniqueOpened and unsubscribed and possible values for Marketing type webhook – spam, opened, click, hardBounce, softBounce, unsubscribed, listAddition and delivered
-   * @member {Array.<String>} events
+   * @member {Array.<module:model/UpdateWebhook.EventsEnum>} events
    */
   exports.prototype['events'] = undefined;
 
+
+  /**
+   * Allowed values for the <code>events</code> property.
+   * @enum {String}
+   * @readonly
+   */
+  exports.EventsEnum = {
+    /**
+     * value: "hardBounce"
+     * @const
+     */
+    "hardBounce": "hardBounce",
+    /**
+     * value: "softBounce"
+     * @const
+     */
+    "softBounce": "softBounce",
+    /**
+     * value: "blocked"
+     * @const
+     */
+    "blocked": "blocked",
+    /**
+     * value: "spam"
+     * @const
+     */
+    "spam": "spam",
+    /**
+     * value: "delivered"
+     * @const
+     */
+    "delivered": "delivered",
+    /**
+     * value: "request"
+     * @const
+     */
+    "request": "request",
+    /**
+     * value: "click"
+     * @const
+     */
+    "click": "click",
+    /**
+     * value: "invalid"
+     * @const
+     */
+    "invalid": "invalid",
+    /**
+     * value: "deferred"
+     * @const
+     */
+    "deferred": "deferred",
+    /**
+     * value: "opened"
+     * @const
+     */
+    "opened": "opened",
+    /**
+     * value: "uniqueOpened"
+     * @const
+     */
+    "uniqueOpened": "uniqueOpened",
+    /**
+     * value: "unsubscribed"
+     * @const
+     */
+    "unsubscribed": "unsubscribed",
+    /**
+     * value: "listAddition"
+     * @const
+     */
+    "listAddition": "listAddition"  };
 
 
   return exports;


### PR DESCRIPTION
Fix enum for array type in create/update webhook models