### PR TITLE
Mixed spec updates

### DIFF
--- a/docs/CreateAttribute.md
+++ b/docs/CreateAttribute.md
@@ -5,7 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **value** | **String** | Value of the attribute. Use only if the attribute&#39;s category is &#39;calculated&#39; or &#39;global&#39; | [optional] 
 **enumeration** | [**[CreateAttributeEnumeration]**](CreateAttributeEnumeration.md) | List of values and labels that the attribute can take. Use only if the attribute&#39;s category is \&quot;category\&quot;. For example, [{&#39;value&#39;:1, &#39;label&#39;:&#39;male&#39;}, {&#39;value&#39;:2, &#39;label&#39;:&#39;female&#39;}] | [optional] 
-**type** | **String** | Type of the attribute. Use only if the attribute&#39;s category is &#39;normal&#39;, &#39;category&#39; or &#39;transactional&#39; ( type &#39;id&#39; is only available if the category is &#39;transactional&#39; attribute &amp; type &#39;category&#39; is only available if the category is &#39;category&#39; attribute ) | [optional] 
+**type** | **String** | Type of the attribute. Use only if the attribute&#39;s category is &#39;normal&#39;, &#39;category&#39; or &#39;transactional&#39; ( type &#39;boolean&#39; is only available if the category is &#39;normal&#39; attribute, type &#39;id&#39; is only available if the category is &#39;transactional&#39; attribute &amp; type &#39;category&#39; is only available if the category is &#39;category&#39; attribute ) | [optional] 
 
 
 <a name="TypeEnum"></a>
@@ -17,6 +17,8 @@ Name | Type | Description | Notes
 * `date` (value: `"date"`)
 
 * `float` (value: `"float"`)
+
+* `boolean` (value: `"boolean"`)
 
 * `id` (value: `"id"`)
 

--- a/docs/EmailCampaignsApi.md
+++ b/docs/EmailCampaignsApi.md
@@ -234,6 +234,8 @@ var apiInstance = new SibApiV3Sdk.EmailCampaignsApi();
 var opts = { 
   'type': "type_example", // String | Filter on the type of the campaigns
   'status': "status_example", // String | Filter on the status of the campaign
+  'startDate': new Date("2013-10-20T19:20:30+01:00"), // Date | Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
+  'endDate': new Date("2013-10-20T19:20:30+01:00"), // Date | Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either 'status' not passed and if passed is set to 'sent' )
   'limit': 500, // Number | Number of documents per page
   'offset': 0 // Number | Index of the first document in the page
 };
@@ -251,6 +253,8 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **type** | **String**| Filter on the type of the campaigns | [optional] 
  **status** | **String**| Filter on the status of the campaign | [optional] 
+ **startDate** | **Date**| Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) | [optional] 
+ **endDate** | **Date**| Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; ) | [optional] 
  **limit** | **Number**| Number of documents per page | [optional] [default to 500]
  **offset** | **Number**| Index of the first document in the page | [optional] [default to 0]
 

--- a/docs/GetExtendedCampaignOverview.md
+++ b/docs/GetExtendedCampaignOverview.md
@@ -17,5 +17,6 @@ Name | Type | Description | Notes
 **inlineImageActivation** | **Boolean** | Status of inline image. inlineImageActivation &#x3D; false means image can’t be embedded, &amp; inlineImageActivation &#x3D; true means image can be embedded, in the email. | [optional] 
 **mirrorActive** | **Boolean** | Status of mirror links in campaign. mirrorActive &#x3D; false means mirror links are deactivated, &amp; mirrorActive &#x3D; true means mirror links are activated, in the campaign | [optional] 
 **recurring** | **Boolean** | FOR TRIGGER ONLY ! Type of trigger campaign.recurring &#x3D; false means contact can receive the same Trigger campaign only once, &amp; recurring &#x3D; true means contact can receive the same Trigger campaign several times | [optional] 
+**sentDate** | **Date** | Sent UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ). Only available if &#39;status&#39; of the campaign is &#39;sent&#39; | [optional] 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sib-api-v3-sdk",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Official SendinBlue provided RESTFul API V3 nodejs library",
   "license": "ISC",
   "main": "src/index.js",

--- a/src/api/EmailCampaignsApi.js
+++ b/src/api/EmailCampaignsApi.js
@@ -262,6 +262,8 @@
      * @param {Object} opts Optional parameters
      * @param {module:model/String} opts.type Filter on the type of the campaigns
      * @param {module:model/String} opts.status Filter on the status of the campaign
+     * @param {Date} opts.startDate Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; )
+     * @param {Date} opts.endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; )
      * @param {Number} opts.limit Number of documents per page (default to 500)
      * @param {Number} opts.offset Index of the first document in the page (default to 0)
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with an object containing data of type {@link module:model/GetEmailCampaigns} and HTTP response
@@ -276,6 +278,8 @@
       var queryParams = {
         'type': opts['type'],
         'status': opts['status'],
+        'startDate': opts['startDate'],
+        'endDate': opts['endDate'],
         'limit': opts['limit'],
         'offset': opts['offset'],
       };
@@ -303,6 +307,8 @@
      * @param {Object} opts Optional parameters
      * @param {module:model/String} opts.type Filter on the type of the campaigns
      * @param {module:model/String} opts.status Filter on the status of the campaign
+     * @param {Date} opts.startDate Mandatory if endDate is used. Starting (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; )
+     * @param {Date} opts.endDate Mandatory if startDate is used. Ending (urlencoded) UTC date-time (YYYY-MM-DDTHH:mm:ss.SSSZ) to filter the sent email campaigns. Prefer to pass your timezone in date-time format for accurate result ( only available if either &#39;status&#39; not passed and if passed is set to &#39;sent&#39; )
      * @param {Number} opts.limit Number of documents per page (default to 500)
      * @param {Number} opts.offset Index of the first document in the page (default to 0)
      * @return {Promise} a {@link https://www.promisejs.org/|Promise}, with data of type {@link module:model/GetEmailCampaigns}

--- a/src/model/CreateAttribute.js
+++ b/src/model/CreateAttribute.js
@@ -88,7 +88,7 @@
    */
   exports.prototype['enumeration'] = undefined;
   /**
-   * Type of the attribute. Use only if the attribute's category is 'normal', 'category' or 'transactional' ( type 'id' is only available if the category is 'transactional' attribute & type 'category' is only available if the category is 'category' attribute )
+   * Type of the attribute. Use only if the attribute's category is 'normal', 'category' or 'transactional' ( type 'boolean' is only available if the category is 'normal' attribute, type 'id' is only available if the category is 'transactional' attribute & type 'category' is only available if the category is 'category' attribute )
    * @member {module:model/CreateAttribute.TypeEnum} type
    */
   exports.prototype['type'] = undefined;
@@ -115,6 +115,11 @@
      * @const
      */
     "float": "float",
+    /**
+     * value: "boolean"
+     * @const
+     */
+    "boolean": "boolean",
     /**
      * value: "id"
      * @const

--- a/src/model/GetEmailCampaign.js
+++ b/src/model/GetEmailCampaign.js
@@ -222,6 +222,12 @@ exports.prototype['mirrorActive'] = undefined;
    */
 exports.prototype['recurring'] = undefined;
 
+  /**
+   * Sent UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ). Only available if 'status' of the campaign is 'sent'
+   * @member {Date} sentDate
+   */
+exports.prototype['sentDate'] = undefined;
+
 
 
   return exports;

--- a/src/model/GetExtendedCampaignOverview.js
+++ b/src/model/GetExtendedCampaignOverview.js
@@ -76,9 +76,6 @@
     _this['tag'] = tag;
     _this['createdAt'] = createdAt;
     _this['modifiedAt'] = modifiedAt;
-
-
-
   };
 
   /**
@@ -134,6 +131,9 @@
       }
       if (data.hasOwnProperty('recurring')) {
         obj['recurring'] = ApiClient.convertToType(data['recurring'], 'Boolean');
+      }
+      if (data.hasOwnProperty('sentDate')) {
+        obj['sentDate'] = ApiClient.convertToType(data['sentDate'], 'Date');
       }
     }
     return obj;
@@ -208,6 +208,11 @@
    * @member {Boolean} recurring
    */
   exports.prototype['recurring'] = undefined;
+  /**
+   * Sent UTC date-time of the campaign (YYYY-MM-DDTHH:mm:ss.SSSZ). Only available if 'status' of the campaign is 'sent'
+   * @member {Date} sentDate
+   */
+  exports.prototype['sentDate'] = undefined;
 
   // Implement GetCampaignOverview interface:
   /**

--- a/test/model/GetExtendedCampaignOverview.spec.js
+++ b/test/model/GetExtendedCampaignOverview.spec.js
@@ -141,6 +141,12 @@
       //expect(instance).to.be();
     });
 
+    it('should have the property sentDate (base name: "sentDate")', function() {
+      // uncomment below and update the code to test the property sentDate
+      //var instane = new SibApiV3Sdk.GetExtendedCampaignOverview();
+      //expect(instance).to.be();
+    });
+
   });
 
 }));


### PR DESCRIPTION
- Added new enum `boolean` for input parameter `type` in `createAttribute` definition
- Added two new query parameters `startDate` & `endDate` in `GET /emailCampaigns` route
- Added a new field `sentDate` in response schema of `getExtendedCampaignOverview` definition